### PR TITLE
Feature/upgrades abstract structure

### DIFF
--- a/Assets/Scripts/Upgrades.meta
+++ b/Assets/Scripts/Upgrades.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fd4b0bcfbd984c64e8031fdd342687d1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/BaseUpgradeScriptableObject.cs
+++ b/Assets/Scripts/Upgrades/BaseUpgradeScriptableObject.cs
@@ -1,0 +1,32 @@
+﻿using UnityEngine;
+
+namespace App.Upgrades
+{
+    public abstract class BaseUpgradeScriptableObject<UpgradableEntity>
+        : ScriptableObject
+        , IDisplayableUpgrade
+        , IUpgradeVisitor<UpgradableEntity>
+
+        where UpgradableEntity : IUpgradable
+    {
+        [SerializeField] private string upgradeName;
+        [SerializeField] private string description;
+        [SerializeField] private Sprite image;
+
+        public Sprite Image => image;
+
+        public string Name => upgradeName;
+
+        public string Description => description;
+
+        public abstract bool IsComplete { get; }
+
+        public abstract bool IsEnabled { get; }
+
+        public abstract void Disable();
+
+        public abstract void Enable(UpgradableEntity upgradable);
+
+        public abstract void LevelUp();
+    }
+}

--- a/Assets/Scripts/Upgrades/BaseUpgradeScriptableObject.cs.meta
+++ b/Assets/Scripts/Upgrades/BaseUpgradeScriptableObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c59cdfea50b3ae24bbb763b122be5073
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/ConcreteUpgrades.meta
+++ b/Assets/Scripts/Upgrades/ConcreteUpgrades.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 692454c5ebd24b54a990ea9088ebcbea
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/ConcreteUpgrades/StandardStrategy.meta
+++ b/Assets/Scripts/Upgrades/ConcreteUpgrades/StandardStrategy.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7ab6d89456dbfbd4eb2af9e2063eefcc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/ConcreteUpgrades/StandardStrategy/IStrategy.cs
+++ b/Assets/Scripts/Upgrades/ConcreteUpgrades/StandardStrategy/IStrategy.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace App.Upgrades.ConcreteUpgrades.StandardStrategy
+{
+    public interface IStrategy<UpgradableEntity, LevelType> where UpgradableEntity : class
+    {
+        void Initialize(UpgradableEntity upgradableEntity);
+        void Reset(UpgradableEntity entity);
+        void SwitchToLevel(UpgradableEntity entity, LevelType level);
+    }
+}

--- a/Assets/Scripts/Upgrades/ConcreteUpgrades/StandardStrategy/IStrategy.cs.meta
+++ b/Assets/Scripts/Upgrades/ConcreteUpgrades/StandardStrategy/IStrategy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 16d0dd8bcffda32468075219fad02aa6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/ConcreteUpgrades/StandardStrategy/PlayerUpgrades.meta
+++ b/Assets/Scripts/Upgrades/ConcreteUpgrades/StandardStrategy/PlayerUpgrades.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 15c4d5791e7e81145a6d65a85a00f153
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/ConcreteUpgrades/StandardStrategy/StandardUpgradeAlgorithm.cs
+++ b/Assets/Scripts/Upgrades/ConcreteUpgrades/StandardStrategy/StandardUpgradeAlgorithm.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+
+namespace App.Upgrades.ConcreteUpgrades.StandardStrategy
+{
+    public class StandardUpgradeAlgorithm<UpgradableEntity, LevelType> : IUpgradeVisitor<UpgradableEntity>
+
+        where UpgradableEntity : class, IUpgradable
+    {
+        private readonly UpgradeLevelManager<LevelType> levelManager;
+        private readonly IStrategy<UpgradableEntity, LevelType> strategy;
+        private UpgradableEntity upgradableEntity;
+
+        public bool IsComplete => levelManager.IsComplete;
+        public bool IsEnabled => (upgradableEntity != null);
+        public UpgradableEntity CurrentUpgradableEntity => upgradableEntity;
+
+        public StandardUpgradeAlgorithm(IStrategy<UpgradableEntity, LevelType> strategy, List<LevelType> levelSet)
+        {
+            this.strategy = strategy;
+            levelManager = new(levelSet);
+        }
+
+        public void Disable()
+        {
+            strategy.Reset(upgradableEntity);
+            upgradableEntity = null;
+        }
+
+        public void Enable(UpgradableEntity upgradable)
+        {
+            upgradableEntity = upgradable;
+            strategy.Initialize(upgradableEntity);
+            strategy.SwitchToLevel(upgradableEntity, levelManager.CurrentLevel);
+        }
+
+        public void LevelUp()
+        {
+            levelManager.LevelUp();
+
+            if (IsEnabled)
+            {
+                strategy.SwitchToLevel(upgradableEntity, levelManager.CurrentLevel);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Upgrades/ConcreteUpgrades/StandardStrategy/StandardUpgradeAlgorithm.cs.meta
+++ b/Assets/Scripts/Upgrades/ConcreteUpgrades/StandardStrategy/StandardUpgradeAlgorithm.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cef3f7f194a9aff4a8dc14194f5fe0b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/ConcreteUpgrades/StandardStrategy/StandardUpgradeScriptableObject.cs
+++ b/Assets/Scripts/Upgrades/ConcreteUpgrades/StandardStrategy/StandardUpgradeScriptableObject.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace App.Upgrades.ConcreteUpgrades.StandardStrategy
+{
+    public class StandardUpgradeScriptableObject<UpgradableEntity, LevelType> : BaseUpgradeScriptableObject<UpgradableEntity>
+
+        where UpgradableEntity : class, IUpgradable
+    {
+        #region Serialized Fields
+        [SerializeField] private List<LevelType> levels;
+        #endregion
+
+        #region Fields
+        private readonly StandardUpgradeAlgorithm<UpgradableEntity, LevelType> upgradeAlgorithm;
+        #endregion
+
+        #region Properties
+        public override bool IsComplete => upgradeAlgorithm.IsComplete;
+        public override bool IsEnabled => upgradeAlgorithm.IsEnabled;
+        #endregion
+
+        #region Constructors
+        public StandardUpgradeScriptableObject(IStrategy<UpgradableEntity, LevelType> strategy)
+        {
+            levels = new();
+            upgradeAlgorithm = new(strategy, levels);
+        }
+        #endregion
+
+        #region Methods
+        public override void Disable()
+        {
+            upgradeAlgorithm.Disable();
+        }
+
+        public override void Enable(UpgradableEntity upgradable)
+        {
+            upgradeAlgorithm.Enable(upgradable);
+        }
+
+        public override void LevelUp()
+        {
+            upgradeAlgorithm.LevelUp();
+        }
+        #endregion
+    }
+}

--- a/Assets/Scripts/Upgrades/ConcreteUpgrades/StandardStrategy/StandardUpgradeScriptableObject.cs.meta
+++ b/Assets/Scripts/Upgrades/ConcreteUpgrades/StandardStrategy/StandardUpgradeScriptableObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5fd3a85e3abd9c499eaa662227fdae2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/ConcreteUpgrades/UpdatableStrategy.meta
+++ b/Assets/Scripts/Upgrades/ConcreteUpgrades/UpdatableStrategy.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e25fd12480c97684b83556ffd544c110
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/ConcreteUpgrades/UpdatableStrategy/IUpdatableStrategy.cs
+++ b/Assets/Scripts/Upgrades/ConcreteUpgrades/UpdatableStrategy/IUpdatableStrategy.cs
@@ -1,0 +1,10 @@
+using App.Upgrades.ConcreteUpgrades.StandardStrategy;
+
+namespace App.Upgrades.ConcreteUpgrades.UpdatableStrategy
+{
+    public interface IUpdatableStrategy<UpgradableEntity, LevelType> : IStrategy<UpgradableEntity, LevelType>
+        where UpgradableEntity : class
+    {
+        void Update(UpgradableEntity upgradableEntity);
+    }
+}

--- a/Assets/Scripts/Upgrades/ConcreteUpgrades/UpdatableStrategy/IUpdatableStrategy.cs.meta
+++ b/Assets/Scripts/Upgrades/ConcreteUpgrades/UpdatableStrategy/IUpdatableStrategy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bda448289fe6b3f4c95726125a678532
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/ConcreteUpgrades/UpdatableStrategy/StandardUpdatableUpgradeAlgorithm.cs
+++ b/Assets/Scripts/Upgrades/ConcreteUpgrades/UpdatableStrategy/StandardUpdatableUpgradeAlgorithm.cs
@@ -1,0 +1,45 @@
+using App.Upgrades.ConcreteUpgrades.StandardStrategy;
+using System.Collections.Generic;
+
+namespace App.Upgrades.ConcreteUpgrades.UpdatableStrategy
+{
+    public class StandardUpdatableUpgradeAlgorithm<UpgradableEntity, LevelType>
+        : IUpgradeVisitor<UpgradableEntity>
+        , IUpdatableUpgradeVisitor
+
+        where UpgradableEntity : class, IUpgradable
+    {
+        private readonly StandardUpgradeAlgorithm<UpgradableEntity, LevelType> nonUpdatableVisitor;
+        private readonly IUpdatableStrategy<UpgradableEntity, LevelType> updatableStrategy;
+
+        public bool IsComplete => nonUpdatableVisitor.IsComplete;
+
+        public bool IsEnabled => nonUpdatableVisitor.IsEnabled;
+
+        public StandardUpdatableUpgradeAlgorithm(IUpdatableStrategy<UpgradableEntity, LevelType> strategy, List<LevelType> levelSet)
+        {
+            nonUpdatableVisitor = new(strategy, levelSet);
+            updatableStrategy = strategy;
+        }
+
+        public void Disable()
+        {
+            nonUpdatableVisitor.Disable();
+        }
+
+        public void Enable(UpgradableEntity upgradable)
+        {
+            nonUpdatableVisitor.Enable(upgradable);
+        }
+
+        public void LevelUp()
+        {
+            nonUpdatableVisitor.LevelUp();
+        }
+
+        public void Update()
+        {
+            updatableStrategy.Update(nonUpdatableVisitor.CurrentUpgradableEntity);
+        }
+    }
+}

--- a/Assets/Scripts/Upgrades/ConcreteUpgrades/UpdatableStrategy/StandardUpdatableUpgradeAlgorithm.cs.meta
+++ b/Assets/Scripts/Upgrades/ConcreteUpgrades/UpdatableStrategy/StandardUpdatableUpgradeAlgorithm.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e3c64943ed437843a5052f373139092
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/ConcreteUpgrades/UpdatableStrategy/StandardUpdatableUpgradeScriptableObject.cs
+++ b/Assets/Scripts/Upgrades/ConcreteUpgrades/UpdatableStrategy/StandardUpdatableUpgradeScriptableObject.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace App.Upgrades.ConcreteUpgrades.UpdatableStrategy
+{
+    public class StandardUpdatableUpgradeScriptableObject<UpgradableEntity, LevelType>
+        : BaseUpgradeScriptableObject<UpgradableEntity>
+        , IUpdatableUpgradeVisitor
+
+        where UpgradableEntity : class, IUpgradable
+    {
+        #region Serialized Fields
+        [SerializeField] private List<LevelType> levels;
+        #endregion
+
+        #region Fields
+        private readonly StandardUpdatableUpgradeAlgorithm<UpgradableEntity, LevelType> upgradeAlgorithm;
+        #endregion
+
+        #region Properties
+        public override bool IsComplete => upgradeAlgorithm.IsComplete;
+        public override bool IsEnabled => upgradeAlgorithm.IsEnabled;
+        #endregion
+
+        #region Constructors
+        public StandardUpdatableUpgradeScriptableObject(IUpdatableStrategy<UpgradableEntity, LevelType> strategy)
+        {
+            levels = new();
+            upgradeAlgorithm = new(strategy, levels);
+        }
+        #endregion
+
+        #region Methods
+        public override void Disable()
+        {
+            upgradeAlgorithm.Disable();
+        }
+
+        public override void Enable(UpgradableEntity upgradable)
+        {
+            upgradeAlgorithm.Enable(upgradable);
+        }
+
+        public override void LevelUp()
+        {
+            upgradeAlgorithm.LevelUp();
+        }
+
+        public void Update()
+        {
+            upgradeAlgorithm.Update();
+        }
+        #endregion
+    }
+}

--- a/Assets/Scripts/Upgrades/ConcreteUpgrades/UpdatableStrategy/StandardUpdatableUpgradeScriptableObject.cs.meta
+++ b/Assets/Scripts/Upgrades/ConcreteUpgrades/UpdatableStrategy/StandardUpdatableUpgradeScriptableObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0085f8aba28bac14994704d82129e5c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/IDisplayableUpgrade.cs
+++ b/Assets/Scripts/Upgrades/IDisplayableUpgrade.cs
@@ -1,0 +1,11 @@
+﻿using UnityEngine;
+
+namespace App.Upgrades
+{
+    public interface IDisplayableUpgrade
+    {
+        Sprite Image { get; }
+        string Name { get; }
+        string Description { get; }
+    }
+}

--- a/Assets/Scripts/Upgrades/IDisplayableUpgrade.cs.meta
+++ b/Assets/Scripts/Upgrades/IDisplayableUpgrade.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6493c7b2850af04e95ce13a3a698902
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/IUpdatableUpgradeVisitor.cs
+++ b/Assets/Scripts/Upgrades/IUpdatableUpgradeVisitor.cs
@@ -1,0 +1,7 @@
+﻿namespace App.Upgrades
+{
+    public interface IUpdatableUpgradeVisitor : IUpgradeAbstractVisitor
+    {
+        void Update();
+    }
+}

--- a/Assets/Scripts/Upgrades/IUpdatableUpgradeVisitor.cs.meta
+++ b/Assets/Scripts/Upgrades/IUpdatableUpgradeVisitor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ad9cdedeb7406f4cacf8acfc56b60af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/IUpgradable.cs
+++ b/Assets/Scripts/Upgrades/IUpgradable.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace App.Upgrades
+{
+    public interface IUpgradable
+    {
+        void EnableUpgrade(IUpgradeAbstractVisitor upgrade);
+
+        public static void EnableUpgradeViaVisitorOf<UpgradableEntity>(UpgradableEntity self, IUpgradeAbstractVisitor visitor)
+            where UpgradableEntity : class, IUpgradable
+        {
+            if (visitor is IUpgradeVisitor<UpgradableEntity>)
+            {
+                IUpgradeVisitor<UpgradableEntity> castedVisitor = visitor as IUpgradeVisitor<UpgradableEntity>;
+                castedVisitor.Enable(self); // do visit
+            }
+            else
+            {
+                throw new InvalidOperationException($"Input abstract visitor does not represent a visitor to upgrade {self.GetType()}.");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Upgrades/IUpgradable.cs.meta
+++ b/Assets/Scripts/Upgrades/IUpgradable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f9272e7641e927643b675c14cc4c74b2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/IUpgradeAbstractVisitor.cs
+++ b/Assets/Scripts/Upgrades/IUpgradeAbstractVisitor.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace App.Upgrades
+{
+    public interface IUpgradeAbstractVisitor
+    {
+        sealed void Enable(IUpgradable upgradable)
+        {
+            var guide = @$"
+                AVDP Guide:
+                Do not call {nameof(IUpgradeAbstractVisitor)}::Enable({nameof(IUpgradable)} upgradable).
+                Instead use a dynamic_cast to concrete type implementing {nameof(IUpgradeAbstractVisitor)}, like 
+                {typeof(IUpgradeVisitor<>).Name}, and call its Enable method instead to perform a double-dispatch 
+                over upgrades.
+            ";
+
+            throw new InvalidOperationException(guide);
+        }
+
+        void Disable();
+        void LevelUp();
+        bool IsComplete { get; }
+        bool IsEnabled { get; }
+    }
+}

--- a/Assets/Scripts/Upgrades/IUpgradeAbstractVisitor.cs.meta
+++ b/Assets/Scripts/Upgrades/IUpgradeAbstractVisitor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: af9c8e934d8df7d4482e934983c9363c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/IUpgradeVisitor.cs
+++ b/Assets/Scripts/Upgrades/IUpgradeVisitor.cs
@@ -1,0 +1,8 @@
+﻿namespace App.Upgrades
+{
+    public interface IUpgradeVisitor<UpgradableEntity> : IUpgradeAbstractVisitor
+        where UpgradableEntity : IUpgradable
+    {
+        void Enable(UpgradableEntity upgradable);
+    }
+}

--- a/Assets/Scripts/Upgrades/IUpgradeVisitor.cs.meta
+++ b/Assets/Scripts/Upgrades/IUpgradeVisitor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6f702a704a159e44a9173a76f6902c9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/UpgradeLevelManager.cs
+++ b/Assets/Scripts/Upgrades/UpgradeLevelManager.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace App.Upgrades
+{
+    public class UpgradeLevelManager<LevelType>
+    {
+        private readonly List<LevelType> levels;
+        private int currentLevelIndex;
+
+        public bool IsComplete { get => currentLevelIndex == levels.Count - 1; }
+        public LevelType CurrentLevel => levels[currentLevelIndex];
+
+        public UpgradeLevelManager(List<LevelType> levels)
+        {
+            this.levels = levels;
+            currentLevelIndex = 0;
+        }
+
+        public void LevelUp()
+        {
+            if (IsComplete)
+            {
+                throw new InvalidOperationException("Cannot level up an upgrade in a complete state.");
+            }
+
+            ++currentLevelIndex;
+        }
+    }
+}

--- a/Assets/Scripts/Upgrades/UpgradeLevelManager.cs.meta
+++ b/Assets/Scripts/Upgrades/UpgradeLevelManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae74d54a250ff974b8f4143323dbcce5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Upgrades/UpgradeManager.cs
+++ b/Assets/Scripts/Upgrades/UpgradeManager.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace App.Upgrades
+{
+    [RequireComponent(typeof(IUpgradable))]
+    public class UpgradeManager : MonoBehaviour
+    {
+        #region Fields
+        private Dictionary<Type, IUpgradeAbstractVisitor> upgrades;
+        private Dictionary<Type, IUpdatableUpgradeVisitor> updatableUpdates;
+        private IUpgradable upgradableEntity;
+        #endregion
+
+        #region MonoBehaviour Methods
+        private void Awake()
+        {
+            upgrades = new();
+            updatableUpdates = new();
+            upgradableEntity = GetComponent<IUpgradable>();
+        }
+
+        private void Update()
+        {
+            UpdateAll();
+        }
+        #endregion
+
+        #region Custom Methods
+
+        public void EnableAll()
+        {
+            foreach (var upgrade in upgrades.Values)
+            {
+                upgradableEntity.EnableUpgrade(upgrade);
+            }
+
+            foreach (var upgrade in updatableUpdates.Values)
+            {
+                upgradableEntity.EnableUpgrade(upgrade);
+            }
+        }
+
+        public void UpdateAll()
+        {
+            foreach (var upgrade in updatableUpdates.Values)
+            {
+                upgrade.Update();
+            }
+        }
+
+        public void DisableAll()
+        {
+            foreach (var upgrade in upgrades.Values)
+            {
+                upgrade.Disable();
+            }
+
+            foreach (var upgrade in updatableUpdates.Values)
+            {
+                upgrade.Disable();
+            }
+        }
+
+        public void AddUpgrade(IUpgradeAbstractVisitor upgrade)
+        {
+            if (upgrade is IUpdatableUpgradeVisitor)
+            {
+                Debug.Log("Updatable added");
+                updatableUpdates.Add(upgrade.GetType(), upgrade as IUpdatableUpgradeVisitor);
+            }
+            else
+            {
+                Debug.Log("Non-Updatable added");
+                upgrades.Add(upgrade.GetType(), upgrade);
+            }
+
+            upgradableEntity.EnableUpgrade(upgrade);
+        }
+
+        public void LevelUpUpgrade(IUpgradeAbstractVisitor upgrade)
+        {
+            IUpgradeAbstractVisitor upgradeToLevelUp = FindUpgrade(upgrade);
+
+            if (upgradeToLevelUp == null)
+            {
+                throw new ArgumentException("Trying to level-up an upgrade absent in UpgradeManager Collection.");
+            }
+
+            if (upgradeToLevelUp.IsComplete)
+            {
+                throw new InvalidOperationException("Impossible to level-up a complete upgrade.");
+            }
+
+            upgradeToLevelUp.LevelUp();
+        }
+
+        public IUpgradeAbstractVisitor FindUpgrade(IUpgradeAbstractVisitor upgrade)
+        {
+
+            if (upgrades.TryGetValue(upgrade.GetType(), out IUpgradeAbstractVisitor upgradeToLevelUp))
+            {
+                return upgradeToLevelUp;
+            }
+            else if (updatableUpdates.TryGetValue(upgrade.GetType(), out IUpdatableUpgradeVisitor updatableUpgradeToLevelUp))
+            {
+                return updatableUpgradeToLevelUp;
+            }
+
+            return null;
+        }
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Upgrades/UpgradeManager.cs.meta
+++ b/Assets/Scripts/Upgrades/UpgradeManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6469136b3a8169146a4f5604f856d914
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Upgrade System
### Approach
The upgrade system is designed in accordance with `Acyclic Visitor Design Pattern (ADVP)`. The inner engine logic of each upgrade is factored out using `Strategy Design Pattern`.

### ADVP Entities
The visiting method is `IUpgradeVisitor::Enable`
- `IUpgradeAbstractVisitor` - abstract "empty" visitor interface (to be dynamic_casted when visitting);
- `IUpgradeVisitor` - generic visitor interface containing specific visiting method;
- `IUpgradable` - interface of a visitable entity.

### Strategies
There two abstract kinds of strategies:
- `IStrategy` - general strategy interface;
- `IUpdatableStrategy` - the general strategy interface extended with `Update` method.

### Upgrade Algorithms
Currently there's only one upgrade algorithm present - Standard Upgrade Algorithm that is implemented for all kinds of strategies. It provides the logic of level incrementing and incapsulating a generic upgrade level type. Present algorithm implementations:
- `StandardUpgradeAlgorithm` - the algorithm for any upgrade strategy;
- `StandardUpdatableUpgradeAlgorithm` - the algorithm for updatable upgrade strategy.

### Upgrade Scriptable Objects
The concrete upgrades are designed to derive from provided ScriptableObject-bases or at least to subclass `BaseUpgradeScriptableObject`. Present ScriptableObject bases:
- `BaseUpgradeScriptableObject` - abstract ScriptableObject-base;
- `StandardUpgradeScriptableObject` - concrete ScriptableObject-base incapsulating standard algorithm for upgrades;
- `StandardUpdatableUpgradeScriptableObject` - concrete ScriptableObject-base incapsulating standard algorithm for updatable upgrades.

### Other Utilities
- `IDisplayableUpgrade` - the interface providing the upgrade's view in the shop;
- `UpgadeMaager` - the entity that is used to enable upgrades for upgradable objects;
- `UpgradeLevelManager` - level manager used by standard upgrade algorithm.